### PR TITLE
Feature multi org unit group persist indicators script

### DIFF
--- a/src/scripts/persist-indicators/index.js
+++ b/src/scripts/persist-indicators/index.js
@@ -80,17 +80,33 @@ AutoIndicatorsLoader.prototype.loadIndicator = function(indicator) {
     var url = this.prepareOptions(this.endpoints.DATASETS.replace("UID", indicator.dataSet));
     request(url, function(error, response, body) {
         indicator.periodType = JSON.parse(body).periodType;
-        //prepare indicator
-        _this.prepareParamIndicator(indicator);
-        //prepare orgunits
-        _this.prepareParamOrgUnits(indicator);        
-        //prepare periods
-        _this.prepareParamPeriod(indicator);
-        //read data + post
-        _this.readAndPost(indicator);
+        if (indicator.orgUnitGroup != undefined) {
+            var orgUnitGroups = indicator.orgUnitGroup.split(";");
+            orgUnitGroups.forEach(function (orgUnitGroup) {
+                indicator.orgUnitGroup = orgUnitGroup;
+                _this.prepareAndPostIndicator(indicator);
+            });
+        } else {
+            this.prepareAndPostIndicator(indicator);
+        }
     });    
 
 };
+
+/**
+ * Prepare and post the indicator with the correct params
+ * @param indicator The indicator that will be enriched with additional readable properties.
+ */
+AutoIndicatorsLoader.prototype.prepareAndPostIndicator = function (indicator) {
+    //prepare indicator
+    this.prepareParamIndicator(indicator);
+    //prepare orgunits
+    this.prepareParamOrgUnits(indicator);
+    //prepare periods
+    this.prepareParamPeriod(indicator);
+    //read data + post
+    this.readAndPost(indicator);
+}
 
 /**
  * Turns codified attribute values into readable properties in the indicator (orgunit, dataset, ...)

--- a/src/scripts/persist-indicators/index.js
+++ b/src/scripts/persist-indicators/index.js
@@ -87,7 +87,7 @@ AutoIndicatorsLoader.prototype.loadIndicator = function(indicator) {
                 _this.prepareAndPostIndicator(indicator);
             });
         } else {
-            this.prepareAndPostIndicator(indicator);
+            _this.prepareAndPostIndicator(indicator);
         }
     });    
 

--- a/src/scripts/persist-indicators/index.js
+++ b/src/scripts/persist-indicators/index.js
@@ -98,6 +98,8 @@ AutoIndicatorsLoader.prototype.loadIndicator = function(indicator) {
  * @param indicator The indicator that will be enriched with additional readable properties.
  */
 AutoIndicatorsLoader.prototype.prepareAndPostIndicator = function (indicator) {
+    //Additional container where analytics params will be added
+    indicator.queryParams = [];
     //prepare indicator
     this.prepareParamIndicator(indicator);
     //prepare orgunits
@@ -124,8 +126,6 @@ AutoIndicatorsLoader.prototype.turnAttributeValuesIntoProperties = function(indi
         //Add straight property to indicator
         indicator[attributeName] = attributeValue;
     }
-    //Additional container where analytics params will be added
-    indicator.queryParams = [];
 }
 
 /**
@@ -195,9 +195,11 @@ AutoIndicatorsLoader.prototype.readAndPost = function(indicator) {
     request(url, function(error, response, body) {
         console.log("\nLoading indicator " + indicator.displayName);
         var rows = JSON.parse(body).rows;
-        console.log(JSON.stringify(rows,null,"\t"));
-        var dataValues = _this.buildDataValues(indicator, rows);
-        _this.postDataValues(dataValues);
+        console.log(JSON.stringify(rows, null, "\t"));
+        if (rows != undefined) {
+            var dataValues = _this.buildDataValues(indicator, rows);
+            _this.postDataValues(dataValues);
+        }
     });    
 };
 

--- a/src/scripts/persist-indicators/package.json
+++ b/src/scripts/persist-indicators/package.json
@@ -8,8 +8,8 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "dependencies": {
-    "moment": "^2.15.2",
-    "request": "^2.75.0"
+    "moment": "^2.18.1",
+    "request": "^2.81.0"
   },
   "author": "Ivan Arrizabalaga",
   "license": "GPL-3.0"


### PR DESCRIPTION
Closes #40
@adrianq I could not test persist-indicators script properly on my dev server. This [request](https://github.com/EyeSeeTea/organisationUnit-User-Assigment/blob/c48f85fe6d53a62fc809b7aecd2f3b96b5594b23/src/scripts/persist-indicators/index.js#L195) never ends. But I think it's independent of this PR.