### PR TITLE
Fix/show user orgunits

### DIFF
--- a/src/List/ContextActions.js
+++ b/src/List/ContextActions.js
@@ -2,6 +2,7 @@ import Action from 'd2-ui/lib/action/Action';
 import detailsStore from './details.store';
 import { config, getInstance as getD2 } from 'd2/lib/d2';
 import orgUnitAssignmentDialogStore from './organisation-unit-dialog/organisationUnitDialogStore';
+import appStateStore from '../App/appStateStore';
 
 config.i18n.strings.add('details');
 config.i18n.strings.add('assignToOrgUnits');
@@ -20,15 +21,13 @@ contextActions.assignToOrgUnits
     .subscribe(async({ data: model }) => {
         const d2 = await getD2();
         const modelItem = await d2.models[model.modelDefinition.name].get(model.id);
-        const rootOrgUnit = await d2.models.organisationUnits.list({
-            paging: false,
-            level: 1,
-            fields: 'id,displayName,children[id,displayName,children::isNotEmpty]',
-        }).then(rootLevel => rootLevel.toArray()[0]);
+        const userOrgUnitRoots = await appStateStore
+            .map(appState => appState.userOrganisationUnits.toArray())
+            .first().toPromise();
 
         orgUnitAssignmentDialogStore.setState({
             model: modelItem,
-            root: rootOrgUnit,
+            roots: userOrgUnitRoots,
             open: true,
         });
     });

--- a/src/List/List.component.js
+++ b/src/List/List.component.js
@@ -104,6 +104,7 @@ const List = React.createClass({
             },
             orgunitassignment: {
                 model: null,
+                roots: [],
                 open: false,
             },
             dataElementOperand: {
@@ -304,7 +305,7 @@ const List = React.createClass({
 
                 {this.state.orgunitassignment.model ? <OrgUnitDialog
                     model={this.state.orgunitassignment.model}
-                    root={this.state.orgunitassignment.root}
+                    roots={this.state.orgunitassignment.roots}
                     open={this.state.orgunitassignment.open}
                     onOrgUnitAssignmentSaved={this._orgUnitAssignmentSaved}
                     onOrgUnitAssignmentError={this._orgUnitAssignmentError}

--- a/src/List/organisation-unit-dialog/OrgUnitDialog.component.js
+++ b/src/List/organisation-unit-dialog/OrgUnitDialog.component.js
@@ -84,6 +84,8 @@ class OrgUnitDialog extends React.Component {
     componentWillReceiveProps(props) {
         if (props.model) {
             this.setState({
+                originalRoots: props.roots,
+                rootOrgUnits: props.roots,
                 selected: props.model.organisationUnits.toArray().map(i => i.id),
             });
         }

--- a/src/List/organisation-unit-dialog/OrgUnitDialog.component.js
+++ b/src/List/organisation-unit-dialog/OrgUnitDialog.component.js
@@ -20,9 +20,9 @@ class OrgUnitDialog extends React.Component {
         super(props, context);
 
         this.state = {
-            searchValue: '',    
-            originalRoots: [this.props.root],        
-            rootOrgUnits: [this.props.root],
+            searchValue: '',
+            originalRoots: this.props.roots,
+            rootOrgUnits: this.props.roots,
             selected: this.props.model.organisationUnits.toArray().map(i => i.id),
             groups: [],
             levels: [],
@@ -68,7 +68,7 @@ class OrgUnitDialog extends React.Component {
 
                 const organisationUnitRequest = this.context.d2.models.organisationUnits
                     .filter().on('displayName').ilike(searchValue)
-                    .list({ fields: 'id,displayName,path,children::isNotEmpty'})
+                    .list({ fields: 'id,displayName,path,children::isNotEmpty', withinUserHierarchy: true })
                     .then(modelCollection => modelCollection.toArray());
 
                 return Observable.fromPromise(organisationUnitRequest);
@@ -279,7 +279,7 @@ class OrgUnitDialog extends React.Component {
 }
 OrgUnitDialog.propTypes = {
     onRequestClose: React.PropTypes.func.isRequired,
-    root: React.PropTypes.object.isRequired,
+    roots: React.PropTypes.arrayOf(React.PropTypes.object).isRequired,
     model: React.PropTypes.object.isRequired,
     onOrgUnitAssignmentSaved: React.PropTypes.func.isRequired,
     onOrgUnitAssignmentError: React.PropTypes.func.isRequired,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -61,6 +61,7 @@ const webpackConfig = {
         alias: {
             react: path.resolve('./node_modules/react'),
             'material-ui': path.resolve('./node_modules/material-ui'),
+            d2: path.resolve('./node_modules/d2'),
         },
     },
     devServer: {


### PR DESCRIPTION
Fixes #45

- Replicates behaviour of dataset/add, shows currentuser.orgunits
- Additional fix: when the popup component was reopen with a previous filter, the filter was enabled (even if the search text was empty, which was still more confusing). Now on open the filtering is reset.